### PR TITLE
Adding Degrees exporting to Wind Direction

### DIFF
--- a/exportInfluxDb.go
+++ b/exportInfluxDb.go
@@ -39,6 +39,7 @@ func (c *client) sendbloomskyToInfluxDB(onebloomsky bloomsky.Bloomsky) {
 		"SustainedWindSpeedMph": onebloomsky.GetSustainedWindSpeedMph(),
 		"SustainedWindSpeedMs":  onebloomsky.GetSustainedWindSpeedMs(),
 		"WindDirection":         onebloomsky.GetWindDirection(),
+		"WindDirectionDeg":      onebloomsky.GetWindDirectionDeg(),
 		"WindGustkmh":           onebloomsky.GetWindGustkmh(),
 		"WindGustMph":           onebloomsky.GetWindGustMph(),
 		"WindGustMs":            onebloomsky.GetWindGustMs(),

--- a/tmpl/bloomsky.txt
+++ b/tmpl/bloomsky.txt
@@ -9,6 +9,7 @@ Bloomsky {{.GetLastCall}}
 {{T "Index UV"}} :			{{.GetIndexUV}}
 {{T "Night"}} :				{{.IsNight}}
 {{T "Wind Direction"}} :		{{.GetWindDirection}}
+{{T "Wind Direction Degrees"}} :		{{.GetWindDirectionDeg}}
 {{T "Wind Gust"}} :			{{.GetWindGustMph}} Mph
 {{T "Sustained Wind"}} :		{{.GetSustainedWindSpeedMph}} Mph
 {{T "Wind Gust"}} :			{{.GetWindGustMs}} Ms

--- a/tmpl/bloomsky.txt
+++ b/tmpl/bloomsky.txt
@@ -9,7 +9,7 @@ Bloomsky {{.GetLastCall}}
 {{T "Index UV"}} :			{{.GetIndexUV}}
 {{T "Night"}} :				{{.IsNight}}
 {{T "Wind Direction"}} :		{{.GetWindDirection}}
-{{T "Wind Direction Degrees"}} :		{{.GetWindDirectionDeg}}
+{{T "Wind Direction Degrees"}} :	{{.GetWindDirectionDeg}}
 {{T "Wind Gust"}} :			{{.GetWindGustMph}} Mph
 {{T "Sustained Wind"}} :		{{.GetSustainedWindSpeedMph}} Mph
 {{T "Wind Gust"}} :			{{.GetWindGustMs}} Ms

--- a/utils_test.go
+++ b/utils_test.go
@@ -7,7 +7,7 @@ func Test_funcName(t *testing.T) {
 		name string
 		want string
 	}{
-		{"Ok", "github.com/patrickalin/bloomsky-client-go.Test_funcName.func1"},
+		{"Ok", "bloomsky-client-go.Test_funcName.func1"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This change depends on a pull request I have against the API (notes in there for the rationale):
https://github.com/patrickalin/bloomsky-api-go/pull/2

It adds Wind Direction Degrees display to the command line and to the InfluxDB exporter.